### PR TITLE
Add a Makefile with install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target/
-
+/elfx86exts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+SHELL = /bin/sh
+CARGO = cargo
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+
+.PHONY: all
+all: elfx86exts
+
+elfx86exts:
+	$(CARGO) build
+	cp target/debug/elfx86exts .
+
+.PHONY: check
+check: elfx86exts
+	cargo test
+
+.PHONY: install
+install: elfx86exts
+	mkdir -p $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) elfx86exts $(DESTDIR)$(bindir)/elfx86exts
+
+.PHONY: uninstall
+uninstall:
+	rm $(bindir)/elfx86exts
+
+.PHONY: clean
+clean:
+	rm -rf target elfx86exts
+

--- a/README.md
+++ b/README.md
@@ -8,4 +8,21 @@ more limited.)
 I have no idea what I'm doing here, but it seems to work. There are several
 Rust crates that make this pretty easy to do.
 
+# License
+
 Licensed under the MIT License.
+
+# Installation
+
+To build and install system-wide:
+
+```
+make
+make install
+```
+
+Or you can build using `cargo` directly:
+
+```
+cargo build
+```


### PR DESCRIPTION
This is a very useful tool. Thanks for sharing!

Would you consider adding `make` support with a `make install` target? This would make it play nice with package managers like Mac Homebrew (which I'd like to use to install elfx86exts on my machines, since we're using it for developing [Octave.app](http://octave-app.org/), like [here](https://github.com/octave-app/octave-app-bundler/issues/42)).

A `make install` target differs from `cargo install` because `cargo install` targets the user-local Crates.io repository under the user home directory, whereas `make install` installs to a system-wide location. (I'm a Cargo newb, so I might be overlooking a more idiomatic Rust way of doing this, but it seems to me like Cargo doesn't cover this use case. Per the [Cargo doco](https://doc.rust-lang.org/book/second-edition/ch14-04-installing-binaries.html), "[cargo install] isn’t intended to replace system packages".)

This PR adds a Makefile for `make` support, including an `install` target and [GNU style](https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html#Makefile-Conventions) conventional directory options. It defers to `cargo` for doing the actual build and test operations, so it's just a thin layer on top of the existing Cargo build system. (I wonder if `make clean` should defer to `cargo clean`, too.)

This PR also tweaks the README to include explicit build instructions. Since I'm a Rust newbie, I didn't know what to do to build this thing when I first encountered it.